### PR TITLE
Add Serde support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,8 @@ script:
   - cargo test --verbose --features "$FEATURES"
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo bench --verbose --features "$FEATURES"; fi
   - cargo doc --verbose --features "$FEATURES"
+
+  - cargo build --verbose --features "$FEATURES serde"
+  - cargo test --verbose --features "$FEATURES serde"
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo bench --verbose --features "$FEATURES serde"; fi
+  - cargo doc --verbose --features "$FEATURES serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ categories = ["data-structures", "no-std"]
 [dependencies]
 scopeguard = { version = "0.3", default-features = false }
 byteorder = { version = "1.0", default-features = false }
+serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 rustc-hash = "1.0"
+serde_test = "1.0"
 
 [features]
 nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@
 extern crate alloc;
 extern crate byteorder;
 extern crate scopeguard;
+#[cfg(feature = "serde")]
+extern crate serde;
 #[cfg(not(feature = "nightly"))]
 extern crate std as alloc;
 
@@ -27,6 +29,19 @@ mod fx;
 mod map;
 mod raw;
 mod set;
+
+#[cfg(feature = "serde")]
+mod size_hint {
+    use core::cmp;
+
+    /// This presumably exists to prevent denial of service attacks.
+    ///
+    /// Original discussion: https://github.com/serde-rs/serde/issues/1114.
+    #[inline]
+    pub(crate) fn cautious(hint: Option<usize>) -> usize {
+        cmp::min(hint.unwrap_or(0), 4096)
+    }
+}
 
 pub mod hash_map {
     //! A hash map implemented with quadratic probing and SIMD lookup.

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,64 @@
+#![cfg(feature = "serde")]
+
+extern crate hashbrown;
+extern crate serde_test;
+
+use hashbrown::{HashMap, HashSet};
+use serde_test::{Token, assert_tokens};
+
+#[test]
+fn map_serde_tokens_empty() {
+    let map = HashMap::<char, u32>::new();
+
+    assert_tokens(&map, &[
+        Token::Map { len: Some(0) },
+        Token::MapEnd,
+    ]);
+}
+
+#[test]
+fn map_serde_tokens() {
+    let mut map = HashMap::new();
+    map.insert('b', 20);
+    map.insert('a', 10);
+    map.insert('c', 30);
+
+    assert_tokens(&map, &[
+        Token::Map { len: Some(3) },
+        Token::Char('a'),
+        Token::I32(10),
+
+        Token::Char('b'),
+        Token::I32(20),
+
+        Token::Char('c'),
+        Token::I32(30),
+        Token::MapEnd,
+    ]);
+}
+
+#[test]
+fn set_serde_tokens_empty() {
+    let set = HashSet::<u32>::new();
+
+    assert_tokens(&set, &[
+        Token::Seq { len: Some(0) },
+        Token::SeqEnd,
+    ]);
+}
+
+#[test]
+fn set_serde_tokens() {
+    let mut set = HashSet::new();
+    set.insert(20);
+    set.insert(10);
+    set.insert(30);
+
+    assert_tokens(&set, &[
+        Token::Seq { len: Some(3) },
+        Token::I32(20),
+        Token::I32(10),
+        Token::I32(30),
+        Token::SeqEnd,
+    ]);
+}


### PR DESCRIPTION
The code is taken as is from upstream Serde impls for `std::collections::{HashMap, HashSet}` barring few syntactic sugar changes.

Closes https://github.com/Amanieu/hashbrown/issues/6.