### PR TITLE
Fix subtraction overflow in generic::Group::match_byte

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
     - rust: stable
       env:
        - TARGET=i586-unknown-linux-gnu
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
       install:
        - rustup target add $TARGET
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,16 @@ matrix:
       env:
        - FEATURES='nightly'
 
+    # test a target without sse2 for raw/generic.rs
+    - rust: stable
+      env:
+       - TARGET=i586-unknown-linux-gnu
+      install:
+       - rustup target add $TARGET
+      script:
+       - cargo build --verbose --target $TARGET
+       - cargo test --verbose --target $TARGET
+
 branches:
   # Don't build these branches
   except:

--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -99,7 +99,7 @@ impl Group {
         // This algorithm is derived from
         // http://graphics.stanford.edu/~seander/bithacks.html##ValueInWord
         let cmp = self.0 ^ repeat(byte);
-        BitMask(((cmp - repeat(0x01)) & !cmp & repeat(0x80)).to_le())
+        BitMask((cmp.wrapping_sub(repeat(0x01)) & !cmp & repeat(0x80)).to_le())
     }
 
     /// Returns a `BitMask` indicating all bytes in the group which are


### PR DESCRIPTION
The former `cmp - repeat(0x1)` would overflow if there was a match in the most
significant byte.  A `wrapping_sub` better matches the C code that this was
derived from.

This generic code is only used on non-SSE2 platforms, so I've also added an
i586 entry to the CI config.