### PR TITLE
fix: enable alloc_layout_extra for nightly feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![cfg_attr(
     feature = "nightly",
-    feature(alloc, allocator_api, ptr_offset_from, test, core_intrinsics)
+    feature(alloc, alloc_layout_extra, allocator_api, ptr_offset_from, test, core_intrinsics)
 )]
 #![warn(missing_docs)]
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -153,7 +153,8 @@ fn calculate_layout<T>(buckets: usize) -> Option<(Layout, usize)> {
     // perform bounds-checking while probing.
     let ctrl = Layout::array::<u8>(buckets + Group::WIDTH)
         .ok()?
-        .align_to(Group::WIDTH);
+        .align_to(Group::WIDTH)
+        .ok()?;
 
     ctrl.extend(data).ok()
 }


### PR DESCRIPTION
The latest nightly builds have apparently put `alloc_layout_extra` behind a feature gate, causing compilation failures with the nightly feature enabled. This adds the feature.

```
error[E0658]: use of unstable library feature 'alloc_layout_extra' (see issue #55724)
   --> /Users/kyleclemens/.cargo/git/checkouts/hashbrown-fc08982fe9a23efa/4496e06/src/raw/mod.rs:147:16
    |
147 |     let data = Layout::array::<T>(buckets).ok()?;
    |                ^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(alloc_layout_extra)] to the crate attributes to enable
```