### PR TITLE
Fix memory leak in par_drain and par_into_iter

### DIFF
--- a/src/external_trait_impls/rayon/map.rs
+++ b/src/external_trait_impls/rayon/map.rs
@@ -496,6 +496,12 @@ mod test_par_map {
         // By the way, ensure that cloning doesn't screw up the dropping.
         drop(hm.clone());
 
+        assert_eq!(key.load(Ordering::Relaxed), 100);
+        assert_eq!(value.load(Ordering::Relaxed), 100);
+
+        // Ensure that dropping the iterator does not leak anything.
+        drop(hm.clone().into_par_iter());
+
         {
             assert_eq!(key.load(Ordering::Relaxed), 100);
             assert_eq!(value.load(Ordering::Relaxed), 100);
@@ -539,6 +545,12 @@ mod test_par_map {
 
         // By the way, ensure that cloning doesn't screw up the dropping.
         drop(hm.clone());
+
+        assert_eq!(key.load(Ordering::Relaxed), 100);
+        assert_eq!(value.load(Ordering::Relaxed), 100);
+
+        // Ensure that dropping the drain iterator does not leak anything.
+        drop(hm.clone().par_drain());
 
         {
             assert_eq!(key.load(Ordering::Relaxed), 100);


### PR DESCRIPTION
Found by @cuviper in #37 