### PR TITLE
Fix cargo build with minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ scopeguard = { version = "0.3", default-features = false }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }
-serde = { version = "1.0", default-features = false, optional = true }
+serde = { version = "1.0.25", default-features = false, optional = true }
 
 [dev-dependencies]
 lazy_static = "~1.2"


### PR DESCRIPTION
For serde versions prior to 1.0.25, hashbrown built with serde feature will result in an error:

```
error[E0407]: method `deserialize_in_place` is not a member of trait `Deserialize`
   --> src/external_trait_impls/serde.rs:164:9
    |
164 | /         fn deserialize_in_place<D>(deserializer: D, place: &mut Self) -> Result<(), D::Error>
165 | |         where
166 | |             D: Deserializer<'de>,
167 | |         {
...   |
197 | |             deserializer.deserialize_seq(SeqInPlaceVisitor(place))
198 | |         }
    | |_________^ not a member of trait `Deserialize`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0407`.
error: Could not compile `hashbrown`.
```

Change serde version to 1.0.25 explicitly will fix build with `cargo -Z minimal-versions build --features serde`