### PR TITLE
Optimize for SSSE3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       env: TARGET=x86_64-unknown-linux-gnu
       script: sh ci/miri.sh
     - name: "rustfmt/clippy"
-      env: TARGET=x86_64-unknown-linux-gnu
+      env: TARGET=i586-unknown-linux-gnu
       script: sh ci/tools.sh
     - name: "docs"
       env: TARGET=x86_64-unknown-linux-gnu
@@ -34,8 +34,14 @@ matrix:
     - name: "x86_64-unknown-linux-gnu (Rust 1.29.0)"
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
+    - name: "i686-unknown-linux-gnu"
+      env: TARGET=i686-unknown-linux-gnu CROSS=1
     - name: "x86_64-apple-darwin"
       env: TARGET=x86_64-apple-darwin
+      os: osx
+      osx_image: xcode10
+    - name: "i686-apple-darwin"
+      env: TARGET=i686-apple-darwin
       os: osx
       osx_image: xcode10
     - name: "x86_64-pc-windows-msvc"
@@ -43,12 +49,20 @@ matrix:
       os: windows
     - name: "x86_64-pc-windows-gnu"
       env: TARGET=x86_64-pc-windows-gnu CROSS=1
+    - name: "i686-pc-windows-gnu"
+      env: TARGET=i686-pc-windows-gnu CROSS=1
 
     # Tier 2/3 targets:
     - name: "i586-unknown-linux-gnu (no SSE2)"
       env: TARGET=i586-unknown-linux-gnu CROSS=1
+    - name: "armv7-unknown-linux-gnueabihf"
+      env: TARGET=armv7-unknown-linux-gnueabihf CROSS=1
     - name: "aarch64-unknown-linux-gnu"
       env: TARGET=aarch64-unknown-linux-gnu CROSS=1
+
+  allow_failures:
+    # FIXME:
+    - name: "armv7-unknown-linux-gnueabihf"
    
 install: travis_retry rustup target add "${TARGET}"
 script: sh ci/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,57 @@
 language: rust
 sudo: false
+rust: nightly
 
 matrix:
   include:
     - name: "miri"
-      rust: nightly
-      install:
-        - rustup component add rust-src
-        - cargo +nightly install --force --git https://github.com/rust-lang/miri miri
-        - cargo install xargo
-      script:
-        - cargo clean
-        - cargo +nightly miri test
-    - rust: 1.29.0
-    - rust: stable
-    - rust: beta
-    - rust: nightly
-    - rust: nightly
-      env:
-       - FEATURES='nightly'
+      env: TARGET=x86_64-unknown-linux-gnu
+      script: sh ci/miri.sh
+    - name: "rustfmt/clippy"
+      env: TARGET=x86_64-unknown-linux-gnu
+      script: sh ci/tools.sh
+    - name: "docs"
+      env: TARGET=x86_64-unknown-linux-gnu
+      script: cargo -vv doc --features nightly,serde,rayon
+      deploy:
+        provider: pages
+        skip-cleanup: true
+        github-token: $GITHUB_TOKEN
+        local-dir: target/doc
+        keep-history: false
+        on:
+          branch: master
 
-    # test a target without sse2 for raw/generic.rs
-    - rust: stable
-      env:
-       - TARGET=i586-unknown-linux-gnu
-      addons:
-        apt:
-          packages:
-            - gcc-multilib
-      install:
-       - rustup target add $TARGET
-      script:
-       - cargo build --verbose --target $TARGET
-       - cargo test --verbose --target $TARGET
+    # Tier 1 targets:
+    - name: "x86_64-unknown-linux-gnu"
+      env: TARGET=x86_64-unknown-linux-gnu
+    - name: "x86_64-unknown-linux-gnu (beta)"
+      rust: beta
+      env: TARGET=x86_64-unknown-linux-gnu
+    - name: "x86_64-unknown-linux-gnu (stable)"
+      rust: stable
+      env: TARGET=x86_64-unknown-linux-gnu
+    - name: "x86_64-unknown-linux-gnu (Rust 1.29.0)"
+      rust: stable
+      env: TARGET=x86_64-unknown-linux-gnu
+    - name: "x86_64-apple-darwin"
+      env: TARGET=x86_64-apple-darwin
+      os: osx
+      osx_image: xcode10
+    - name: "x86_64-pc-windows-msvc"
+      env: TARGET=x86_64-pc-windows-msvc
+      os: windows
+    - name: "x86_64-pc-windows-gnu"
+      env: TARGET=x86_64-pc-windows-gnu CROSS=1
+
+    # Tier 2/3 targets:
+    - name: "i586-unknown-linux-gnu (no SSE2)"
+      env: TARGET=i586-unknown-linux-gnu CROSS=1
+    - name: "aarch64-unknown-linux-gnu"
+      env: TARGET=aarch64-unknown-linux-gnu CROSS=1
+   
+install: travis_retry rustup target add "${TARGET}"
+script: sh ci/run.sh
 
 branches:
   # Don't build these branches
@@ -40,19 +59,3 @@ branches:
     # Used by bors
     - trying.tmp
     - staging.tmp
-
-before_script:
-  - if [ "$TRAVIS_RUST_VERSION" == "stable" ]; then rustup component add rustfmt; fi
-
-script:
-  - if [ "$TRAVIS_RUST_VERSION" == "stable" ]; then cargo fmt -- --check; fi
-
-  - cargo build --verbose --features "$FEATURES"
-  - cargo test --verbose --features "$FEATURES"
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo bench --verbose --features "$FEATURES"; fi
-  - cargo doc --verbose --features "$FEATURES"
-
-  - cargo build --verbose --features "$FEATURES serde"
-  - cargo test --verbose --features "$FEATURES serde"
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo bench --verbose --features "$FEATURES serde"; fi
-  - cargo doc --verbose --features "$FEATURES serde"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,11 @@ matrix:
     - name: "x86_64-unknown-linux-gnu (Rust 1.29.0)"
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
+    - name: "x86_64-unknown-linux-gnu (SSSE3)"
+      env: TARGET=x86_64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+ssse3"
     - name: "i686-unknown-linux-gnu"
       env: TARGET=i686-unknown-linux-gnu CROSS=1
-    - name: "x86_64-apple-darwin"
+    - name: "x86_64-apple-darwin (SSSE3)"
       env: TARGET=x86_64-apple-darwin
       os: osx
       osx_image: xcode10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ rustc-hash = "1.0"
 serde_test = "1.0"
 
 [features]
+default = []
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,13 @@ serde_test = "1.0"
 [features]
 default = []
 nightly = []
+
+[profile.bench]
+opt-level = 3
+debug = false
+rpath = false
+lto = "fat"
+debug-assertions = false
+codegen-units = 1
+incremental = false
+overflow-checks = false

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -ex
+
+export CARGO_NET_RETRY=5
+export CARGO_NET_TIMEOUT=10
+
+if cargo install --force --git https://github.com/rust-lang/miri miri ; then
+    cargo miri setup
+    cargo miri test
+fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+
+set -ex
+
+: "${TARGET?The TARGET environment variable must be set.}"
+
+FEATURES="rayon,serde"
+if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
+    FEATURES="${FEATURES},nightly"
+fi
+
+CARGO=cargo
+if [ "${CROSS}" = "1" ]; then
+    export CARGO_NET_RETRY=5
+    export CARGO_NET_TIMEOUT=10
+
+    cargo install cross
+    CARGO=cross
+fi
+
+"${CARGO}" -vv test --target="${TARGET}"
+"${CARGO}" -vv test --target="${TARGET}" --features "${FEATURES}"
+
+"${CARGO}" -vv test --target="${TARGET}" --release
+"${CARGO}" -vv test --target="${TARGET}" --features "${FEATURES}"
+
+if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
+    # Run benchmark on native targets, build them on non-native ones:
+    NO_RUN=""
+    if [ "${CROSS}" = "1" ]; then
+        NO_RUN="--no-run"
+    fi
+
+    "${CARGO}" -vv bench "${NO_RUN}" --features "${FEATURES}"
+fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -7,6 +7,7 @@ set -ex
 FEATURES="rayon,serde"
 if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
     FEATURES="${FEATURES},nightly"
+    export RUSTFLAGS="$RUSTFLAGS --cfg hashbrown_deny_warnings"
 fi
 
 CARGO=cargo
@@ -17,6 +18,8 @@ if [ "${CROSS}" = "1" ]; then
     cargo install cross
     CARGO=cross
 fi
+
+export RUSTFLAGS="$RUSTFLAGS --cfg hashbrown_deny_warnings"
 
 "${CARGO}" -vv test --target="${TARGET}"
 "${CARGO}" -vv test --target="${TARGET}" --features "${FEATURES}"

--- a/ci/tools.sh
+++ b/ci/tools.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+
+set -ex
+
+retry() {
+    result=0
+    count=1
+    max=5
+    while [ "$count" -le 3 ]; do
+        [ "$result" -ne 0 ] && {
+            printf "\nRetrying, %d of %d\n" $count $max >&2
+        }
+        "$@"
+        result=$?
+        [ $result -eq 0 ] && break
+        count=$(count + 1)
+        sleep 1
+    done
+
+    [ "$count" -gt 3 ] && {
+        printf "\nFailed %d times.\n" $max >&2
+    }
+
+    return $result
+}
+
+
+if retry rustup component add rustfmt ; then
+    cargo fmt --all -- --check
+fi
+
+if retry rustup component add clippy ; then
+    cargo clippy --all -- -D clippy::pedantic
+fi
+
+if command -v shellcheck ; then
+    shellcheck --version
+    shellcheck ci/*.sh
+fi

--- a/ci/tools.sh
+++ b/ci/tools.sh
@@ -33,6 +33,12 @@ if retry rustup component add clippy ; then
     cargo clippy --all -- -D clippy::pedantic
 fi
 
+if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+    if retry rustup component add clippy ; then
+        cargo clippy --all --target=i586-unknown-linux-gnu -- -D clippy::pedantic
+    fi
+fi
+
 if command -v shellcheck ; then
     shellcheck --version
     shellcheck ci/*.sh

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = [ "CppCon", "SwissTable", "SipHash", "HashDoS" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! map, adapted to make it a drop-in replacement for Rust's standard `HashMap`
 //! and `HashSet` types.
 //!
-//! The original C++ version of SwissTable can be found [here], and this
+//! The original C++ version of [SwissTable] can be found [here], and this
 //! [CppCon talk] gives an overview of how the algorithm works.
 //!
 //! [SwissTable]: https://abseil.io/blog/20180927-swisstables
@@ -24,6 +24,7 @@
 )]
 #![warn(missing_docs)]
 #![cfg_attr(hashbrown_deny_warnings, deny(warnings))]
+#![allow(clippy::module_name_repetitions)]
 
 #[cfg(test)]
 #[macro_use]
@@ -31,7 +32,6 @@
 extern crate std;
 #[cfg(test)]
 extern crate rand;
-
 
 #[cfg(feature = "nightly")]
 #[cfg_attr(test, macro_use)]
@@ -87,7 +87,7 @@ pub mod hash_set {
 pub use map::HashMap;
 pub use set::HashSet;
 
-/// Augments `AllocErr` with a CapacityOverflow variant.
+/// Augments `AllocErr` with a `CapacityOverflow` variant.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum CollectionAllocErr {
     /// Error due to the computed capacity exceeding the collection's maximum

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,12 +23,15 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(hashbrown_deny_warnings, deny(warnings))]
 
 #[cfg(test)]
 #[macro_use]
+#[allow(unused_imports)]
 extern crate std;
 #[cfg(test)]
 extern crate rand;
+
 
 #[cfg(feature = "nightly")]
 #[cfg_attr(test, macro_use)]

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,5 +1,3 @@
-use self::Entry::*;
-
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
 use core::hash::{BuildHasher, Hash, Hasher};
@@ -212,8 +210,8 @@ impl<K: Hash + Eq, V> HashMap<K, V, DefaultHashBuilder> {
     /// let mut map: HashMap<&str, i32> = HashMap::new();
     /// ```
     #[inline]
-    pub fn new() -> HashMap<K, V, DefaultHashBuilder> {
-        Default::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Creates an empty `HashMap` with the specified capacity.
@@ -228,8 +226,8 @@ impl<K: Hash + Eq, V> HashMap<K, V, DefaultHashBuilder> {
     /// let mut map: HashMap<&str, i32> = HashMap::with_capacity(10);
     /// ```
     #[inline]
-    pub fn with_capacity(capacity: usize) -> HashMap<K, V, DefaultHashBuilder> {
-        HashMap::with_capacity_and_hasher(capacity, Default::default())
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::with_capacity_and_hasher(capacity, DefaultHashBuilder::default())
     }
 }
 
@@ -259,8 +257,8 @@ where
     /// map.insert(1, 2);
     /// ```
     #[inline]
-    pub fn with_hasher(hash_builder: S) -> HashMap<K, V, S> {
-        HashMap {
+    pub fn with_hasher(hash_builder: S) -> Self {
+        Self {
             hash_builder,
             table: RawTable::new(),
         }
@@ -288,8 +286,8 @@ where
     /// map.insert(1, 2);
     /// ```
     #[inline]
-    pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> HashMap<K, V, S> {
-        HashMap {
+    pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
+        Self {
             hash_builder,
             table: RawTable::with_capacity(capacity),
         }
@@ -1023,7 +1021,7 @@ where
     V: PartialEq,
     S: BuildHasher,
 {
-    fn eq(&self, other: &HashMap<K, V, S>) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
             return false;
         }
@@ -1059,8 +1057,8 @@ where
 {
     /// Creates an empty `HashMap<K, V, S>`, with the `Default` value for the hasher.
     #[inline]
-    fn default() -> HashMap<K, V, S> {
-        HashMap::with_hasher(Default::default())
+    fn default() -> Self {
+        Self::with_hasher(Default::default())
     }
 }
 
@@ -1245,7 +1243,7 @@ pub struct ValuesMut<'a, K: 'a, V: 'a> {
     inner: IterMut<'a, K, V>,
 }
 
-/// A builder for computing where in a HashMap a key-value pair would be stored.
+/// A builder for computing where in a [`HashMap`] a key-value pair would be stored.
 ///
 /// See the [`HashMap::raw_entry_mut`] docs for usage examples.
 ///
@@ -1288,7 +1286,7 @@ pub struct RawVacantEntryMut<'a, K: 'a, V: 'a, S: 'a> {
     hash_builder: &'a S,
 }
 
-/// A builder for computing where in a HashMap a key-value pair would be stored.
+/// A builder for computing where in a [`HashMap`] a key-value pair would be stored.
 ///
 /// See the [`HashMap::raw_entry`] docs for usage examples.
 ///
@@ -1304,6 +1302,7 @@ where
 {
     /// Create a `RawEntryMut` from the given key.
     #[inline]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_key<Q: ?Sized>(self, k: &Q) -> RawEntryMut<'a, K, V, S>
     where
         K: Borrow<Q>,
@@ -1316,6 +1315,7 @@ where
 
     /// Create a `RawEntryMut` from the given key and its hash.
     #[inline]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_key_hashed_nocheck<Q: ?Sized>(self, hash: u64, k: &Q) -> RawEntryMut<'a, K, V, S>
     where
         K: Borrow<Q>,
@@ -1343,6 +1343,7 @@ where
 
     /// Create a `RawEntryMut` from the given hash.
     #[inline]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_hash<F>(self, hash: u64, is_match: F) -> RawEntryMut<'a, K, V, S>
     where
         for<'b> F: FnMut(&'b K) -> bool,
@@ -1357,6 +1358,7 @@ where
 {
     /// Access an entry by key.
     #[inline]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_key<Q: ?Sized>(self, k: &Q) -> Option<(&'a K, &'a V)>
     where
         K: Borrow<Q>,
@@ -1369,6 +1371,7 @@ where
 
     /// Access an entry by a key and its hash.
     #[inline]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_key_hashed_nocheck<Q: ?Sized>(self, hash: u64, k: &Q) -> Option<(&'a K, &'a V)>
     where
         K: Borrow<Q>,
@@ -1393,6 +1396,7 @@ where
 
     /// Access an entry by hash.
     #[inline]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_hash<F>(self, hash: u64, is_match: F) -> Option<(&'a K, &'a V)>
     where
         F: FnMut(&K) -> bool,
@@ -1614,6 +1618,7 @@ impl<'a, K, V, S> RawVacantEntryMut<'a, K, V, S> {
     /// Sets the value of the entry with the VacantEntry's key,
     /// and returns a mutable reference to it.
     #[inline]
+    #[allow(clippy::shadow_unrelated)]
     pub fn insert_hashed_nocheck(self, hash: u64, key: K, value: V) -> (&'a mut K, &'a mut V)
     where
         K: Hash,
@@ -1683,8 +1688,8 @@ pub enum Entry<'a, K: 'a, V: 'a, S: 'a> {
 impl<'a, K: 'a + Debug + Eq + Hash, V: 'a + Debug, S: 'a> Debug for Entry<'a, K, V, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Vacant(ref v) => f.debug_tuple("Entry").field(v).finish(),
-            Occupied(ref o) => f.debug_tuple("Entry").field(o).finish(),
+            Entry::Vacant(ref v) => f.debug_tuple("Entry").field(v).finish(),
+            Entry::Occupied(ref o) => f.debug_tuple("Entry").field(o).finish(),
         }
     }
 }
@@ -2007,8 +2012,8 @@ impl<'a, K, V, S> Entry<'a, K, V, S> {
         S: BuildHasher,
     {
         match self {
-            Occupied(entry) => entry.into_mut(),
-            Vacant(entry) => entry.insert(default),
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default),
         }
     }
 
@@ -2034,8 +2039,8 @@ impl<'a, K, V, S> Entry<'a, K, V, S> {
         S: BuildHasher,
     {
         match self {
-            Occupied(entry) => entry.into_mut(),
-            Vacant(entry) => entry.insert(default()),
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default()),
         }
     }
 
@@ -2052,8 +2057,8 @@ impl<'a, K, V, S> Entry<'a, K, V, S> {
     #[inline]
     pub fn key(&self) -> &K {
         match *self {
-            Occupied(ref entry) => entry.key(),
-            Vacant(ref entry) => entry.key(),
+            Entry::Occupied(ref entry) => entry.key(),
+            Entry::Vacant(ref entry) => entry.key(),
         }
     }
 
@@ -2083,11 +2088,11 @@ impl<'a, K, V, S> Entry<'a, K, V, S> {
         F: FnOnce(&mut V),
     {
         match self {
-            Occupied(mut entry) => {
+            Entry::Occupied(mut entry) => {
                 f(entry.get_mut());
-                Occupied(entry)
+                Entry::Occupied(entry)
             }
-            Vacant(entry) => Vacant(entry),
+            Entry::Vacant(entry) => Entry::Vacant(entry),
         }
     }
 }
@@ -2115,8 +2120,8 @@ impl<'a, K, V: Default, S> Entry<'a, K, V, S> {
         S: BuildHasher,
     {
         match self {
-            Occupied(entry) => entry.into_mut(),
-            Vacant(entry) => entry.insert(Default::default()),
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(Default::default()),
         }
     }
 }
@@ -2423,9 +2428,9 @@ where
     S: BuildHasher + Default,
 {
     #[inline]
-    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> HashMap<K, V, S> {
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
         let iter = iter.into_iter();
-        let mut map = HashMap::with_capacity_and_hasher(iter.size_hint().0, Default::default());
+        let mut map = Self::with_capacity_and_hasher(iter.size_hint().0, S::default());
         for (k, v) in iter {
             map.insert(k, v);
         }

--- a/src/raw/bitmask.rs
+++ b/src/raw/bitmask.rs
@@ -20,15 +20,15 @@ impl BitMask {
     /// Returns a new `BitMask` with all bits inverted.
     #[inline]
     #[must_use]
-    pub fn invert(self) -> BitMask {
-        BitMask(self.0 ^ BITMASK_MASK)
+    pub fn invert(self) -> Self {
+        Self(self.0 ^ BITMASK_MASK)
     }
 
     /// Returns a new `BitMask` with the lowest bit removed.
     #[inline]
     #[must_use]
-    pub fn remove_lowest_bit(self) -> BitMask {
-        BitMask(self.0 & (self.0 - 1))
+    pub fn remove_lowest_bit(self) -> Self {
+        Self(self.0 & (self.0 - 1))
     }
     /// Returns whether the `BitMask` has at least one set bit.
     #[inline]

--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -21,12 +21,13 @@ type GroupWord = u32;
 pub type BitMaskWord = GroupWord;
 pub const BITMASK_STRIDE: usize = 8;
 // We only care about the highest bit of each byte for the mask.
-pub const BITMASK_MASK: BitMaskWord = 0x8080_8080_8080_8080u64 as GroupWord;
+#[allow(clippy::cast_possible_truncation)]
+pub const BITMASK_MASK: BitMaskWord = 0x8080_8080_8080_8080_u64 as GroupWord;
 
 /// Helper function to replicate a byte across a `GroupWord`.
 #[inline]
 fn repeat(byte: u8) -> GroupWord {
-    let repeat = byte as GroupWord;
+    let repeat = GroupWord::from(byte);
     let repeat = repeat | repeat.wrapping_shl(8);
     let repeat = repeat | repeat.wrapping_shl(16);
     // This last line is a no-op with a 32-bit GroupWord
@@ -44,6 +45,7 @@ pub struct Group(GroupWord);
 // little-endian just before creating a BitMask. The can potentially
 // enable the compiler to eliminate unnecessary byte swaps if we are
 // only checking whether a BitMask is empty.
+#[allow(clippy::use_self)]
 impl Group {
     /// Number of bytes in the group.
     pub const WIDTH: usize = mem::size_of::<Self>();
@@ -66,23 +68,28 @@ impl Group {
 
     /// Loads a group of bytes starting at the given address.
     #[inline]
-    pub unsafe fn load(ptr: *const u8) -> Group {
-        Group(ptr::read_unaligned(ptr as *const _))
+    #[allow(clippy::cast_ptr_alignment)] // unaligned load
+    pub unsafe fn load(ptr: *const u8) -> Self {
+        Self(ptr::read_unaligned(ptr as *const _))
     }
 
     /// Loads a group of bytes starting at the given address, which must be
     /// aligned to `mem::align_of::<Group>()`.
     #[inline]
-    pub unsafe fn load_aligned(ptr: *const u8) -> Group {
-        debug_assert_eq!(ptr as usize & (mem::align_of::<Group>() - 1), 0);
-        Group(ptr::read(ptr as *const _))
+    #[allow(clippy::cast_ptr_alignment)]
+    pub unsafe fn load_aligned(ptr: *const u8) -> Self {
+        // FIXME: use align_offset once it stabilizes
+        debug_assert_eq!(ptr as usize & (mem::align_of::<Self>() - 1), 0);
+        Self(ptr::read(ptr as *const _))
     }
 
     /// Stores the group of bytes to the given address, which must be
     /// aligned to `mem::align_of::<Group>()`.
     #[inline]
-    pub unsafe fn store_aligned(&self, ptr: *mut u8) {
-        debug_assert_eq!(ptr as usize & (mem::align_of::<Group>() - 1), 0);
+    #[allow(clippy::cast_ptr_alignment)]
+    pub unsafe fn store_aligned(self, ptr: *mut u8) {
+        // FIXME: use align_offset once it stabilizes
+        debug_assert_eq!(ptr as usize & (mem::align_of::<Self>() - 1), 0);
         ptr::write(ptr as *mut _, self.0);
     }
 
@@ -97,7 +104,7 @@ impl Group {
     /// - This only happens if there is at least 1 true match.
     /// - The chance of this happening is very low (< 1% chance per byte).
     #[inline]
-    pub fn match_byte(&self, byte: u8) -> BitMask {
+    pub fn match_byte(self, byte: u8) -> BitMask {
         // This algorithm is derived from
         // http://graphics.stanford.edu/~seander/bithacks.html##ValueInWord
         let cmp = self.0 ^ repeat(byte);
@@ -107,7 +114,7 @@ impl Group {
     /// Returns a `BitMask` indicating all bytes in the group which are
     /// `EMPTY`.
     #[inline]
-    pub fn match_empty(&self) -> BitMask {
+    pub fn match_empty(self) -> BitMask {
         // If the high bit is set, then the byte must be either:
         // 1111_1111 (EMPTY) or 1000_0000 (DELETED).
         // So we can just check if the top two bits are 1 by ANDing them.
@@ -117,7 +124,7 @@ impl Group {
     /// Returns a `BitMask` indicating all bytes in the group which are
     /// `EMPTY` or `DELETED`.
     #[inline]
-    pub fn match_empty_or_deleted(&self) -> BitMask {
+    pub fn match_empty_or_deleted(self) -> BitMask {
         // A byte is EMPTY or DELETED iff the high bit is set
         BitMask((self.0 & repeat(0x80)).to_le())
     }
@@ -127,7 +134,7 @@ impl Group {
     /// - `DELETED => EMPTY`
     /// - `FULL => DELETED`
     #[inline]
-    pub fn convert_special_to_empty_and_full_to_deleted(&self) -> Group {
+    pub fn convert_special_to_empty_and_full_to_deleted(self) -> Self {
         // Map high_bit = 1 (EMPTY or DELETED) to 1111_1111
         // and high_bit = 0 (FULL) to 1000_0000
         //
@@ -136,6 +143,6 @@ impl Group {
         //   !1000_0000 + 1 = 0111_1111 + 1 = 1000_0000 (no carry)
         //   !0000_0000 + 0 = 1111_1111 + 0 = 1111_1111 (no carry)
         let full = !self.0 & repeat(0x80);
-        Group(!full + (full >> 7))
+        Self(!full + (full >> 7))
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -129,8 +129,8 @@ impl<T: Hash + Eq> HashSet<T, DefaultHashBuilder> {
     /// let set: HashSet<i32> = HashSet::new();
     /// ```
     #[inline]
-    pub fn new() -> HashSet<T, DefaultHashBuilder> {
-        HashSet {
+    pub fn new() -> Self {
+        Self {
             map: HashMap::new(),
         }
     }
@@ -148,8 +148,8 @@ impl<T: Hash + Eq> HashSet<T, DefaultHashBuilder> {
     /// assert!(set.capacity() >= 10);
     /// ```
     #[inline]
-    pub fn with_capacity(capacity: usize) -> HashSet<T, DefaultHashBuilder> {
-        HashSet {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
             map: HashMap::with_capacity(capacity),
         }
     }
@@ -181,8 +181,8 @@ where
     /// set.insert(2);
     /// ```
     #[inline]
-    pub fn with_hasher(hasher: S) -> HashSet<T, S> {
-        HashSet {
+    pub fn with_hasher(hasher: S) -> Self {
+        Self {
             map: HashMap::with_hasher(hasher),
         }
     }
@@ -209,8 +209,8 @@ where
     /// set.insert(1);
     /// ```
     #[inline]
-    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> HashSet<T, S> {
-        HashSet {
+    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
+        Self {
             map: HashMap::with_capacity_and_hasher(capacity, hasher),
         }
     }
@@ -384,7 +384,7 @@ where
     /// assert_eq!(diff, [4].iter().collect());
     /// ```
     #[inline]
-    pub fn difference<'a>(&'a self, other: &'a HashSet<T, S>) -> Difference<'a, T, S> {
+    pub fn difference<'a>(&'a self, other: &'a Self) -> Difference<'a, T, S> {
         Difference {
             iter: self.iter(),
             other,
@@ -413,10 +413,7 @@ where
     /// assert_eq!(diff1, [1, 4].iter().collect());
     /// ```
     #[inline]
-    pub fn symmetric_difference<'a>(
-        &'a self,
-        other: &'a HashSet<T, S>,
-    ) -> SymmetricDifference<'a, T, S> {
+    pub fn symmetric_difference<'a>(&'a self, other: &'a Self) -> SymmetricDifference<'a, T, S> {
         SymmetricDifference {
             iter: self.difference(other).chain(other.difference(self)),
         }
@@ -441,7 +438,7 @@ where
     /// assert_eq!(intersection, [2, 3].iter().collect());
     /// ```
     #[inline]
-    pub fn intersection<'a>(&'a self, other: &'a HashSet<T, S>) -> Intersection<'a, T, S> {
+    pub fn intersection<'a>(&'a self, other: &'a Self) -> Intersection<'a, T, S> {
         Intersection {
             iter: self.iter(),
             other,
@@ -467,7 +464,7 @@ where
     /// assert_eq!(union, [1, 2, 3, 4].iter().collect());
     /// ```
     #[inline]
-    pub fn union<'a>(&'a self, other: &'a HashSet<T, S>) -> Union<'a, T, S> {
+    pub fn union<'a>(&'a self, other: &'a Self) -> Union<'a, T, S> {
         Union {
             iter: self.iter().chain(other.difference(self)),
         }
@@ -619,7 +616,7 @@ where
     /// b.insert(1);
     /// assert_eq!(a.is_disjoint(&b), false);
     /// ```
-    pub fn is_disjoint(&self, other: &HashSet<T, S>) -> bool {
+    pub fn is_disjoint(&self, other: &Self) -> bool {
         self.iter().all(|v| !other.contains(v))
     }
 
@@ -640,7 +637,7 @@ where
     /// set.insert(4);
     /// assert_eq!(set.is_subset(&sup), false);
     /// ```
-    pub fn is_subset(&self, other: &HashSet<T, S>) -> bool {
+    pub fn is_subset(&self, other: &Self) -> bool {
         self.iter().all(|v| other.contains(v))
     }
 
@@ -665,7 +662,7 @@ where
     /// assert_eq!(set.is_superset(&sub), true);
     /// ```
     #[inline]
-    pub fn is_superset(&self, other: &HashSet<T, S>) -> bool {
+    pub fn is_superset(&self, other: &Self) -> bool {
         other.is_subset(self)
     }
 
@@ -801,7 +798,7 @@ where
     T: Eq + Hash,
     S: BuildHasher,
 {
-    fn eq(&self, other: &HashSet<T, S>) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
             return false;
         }
@@ -833,8 +830,8 @@ where
     S: BuildHasher + Default,
 {
     #[inline]
-    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> HashSet<T, S> {
-        let mut set = HashSet::with_hasher(Default::default());
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut set = Self::with_hasher(Default::default());
         set.extend(iter);
         set
     }
@@ -869,8 +866,8 @@ where
 {
     /// Creates an empty `HashSet<T, S>` with the `Default` value for the hasher.
     #[inline]
-    fn default() -> HashSet<T, S> {
-        HashSet {
+    fn default() -> Self {
+        Self {
             map: HashMap::default(),
         }
     }


### PR DESCRIPTION
Some targets, like `x86_64-apple-darwin`, always have SSSE3 enabled. Swiss Table has two tiny optimization for SSSE3. This PR implements one of them, see https://github.com/abseil/abseil-cpp/blob/38b704384cd2f17590b3922b97744be0b43622c9/absl/container/internal/raw_hash_set.h#L374.

This PR implements this optimization. Benches before (Haswell):

```
test find_existing     ... bench:       4,160 ns/iter (+/- 1,636)
test find_nonexisting  ... bench:       2,538 ns/iter (+/- 733)
test get_remove_insert ... bench:          29 ns/iter (+/- 22)
test grow_by_insertion ... bench:         164 ns/iter (+/- 28)
test hashmap_as_queue  ... bench:          24 ns/iter (+/- 16)
test new_drop          ... bench:           0 ns/iter (+/- 0)
test new_insert_drop   ... bench:         123 ns/iter (+/- 61)
```

Benches after:

```
test find_existing     ... bench:       3,696 ns/iter (+/- 1,932)
test find_nonexisting  ... bench:       2,566 ns/iter (+/- 725)
test get_remove_insert ... bench:          28 ns/iter (+/- 14)
test grow_by_insertion ... bench:         162 ns/iter (+/- 33)
test hashmap_as_queue  ... bench:          23 ns/iter (+/- 14)
test new_drop          ... bench:           0 ns/iter (+/- 0)
test new_insert_drop   ... bench:         126 ns/iter (+/- 71)
```

The different code gen can be analyzed here: https://rust.godbolt.org/z/iCIKte

I've piped it through LLVM-MCA and Intel's IACA tools, and they show for Skylake:

* Before (SSE2):
    * IACA: cycles/it 1.51, uOps/it 9
    * LLVM-MCA: cycles 804 / 1000 it, uOps/cyc 1.12 (https://rust.godbolt.org/z/20S8c4)

* After (SSSE3):
    * IACA: cycles/it 1.49, uOps/it 9
    * LLVM-MCA SSSE3: cycles 161 / 900 it, uOps/cyc 5.59 (https://rust.godbolt.org/z/0NcwpB)

The model that LLVM-MCA uses looks completely wrong (it predicts the SSSE3 version to be 5x faster), but the model IACA uses looks more realistic, predicting a smaller advantage for the SSSE3 version, which is close to what I've observed in practice. Somebody with Skylake should try to reproduce. 

Basically IACA predicts that both take 9 uOps, but the SSSE3 version puts less pressure on the Ports 1-3:

### SSE2 IACA

```
Intel(R) Architecture Code Analyzer Version -  v3.0-28-g1ba2cbb build date: 2017-10-30;16:57:45
Analyzed File -  sse2
Binary Format - 64Bit
Architecture  -  HSW
Analysis Type - Throughput

Throughput Analysis Report
--------------------------
Block Throughput: 1.51 Cycles       Throughput Bottleneck: FrontEnd
Loop Count:  50
Port Binding In Cycles Per Iteration:
--------------------------------------------------------------------------------------------------
|  Port  |   0   -  DV   |   1   |   2   -  D    |   3   -  D    |   4   |   5   |   6   |   7   |
--------------------------------------------------------------------------------------------------
| Cycles |  0.0     0.0  |  1.0  |  1.0     1.0  |  1.0     1.0  |  1.0  |  1.0  |  1.0  |  1.0  |
--------------------------------------------------------------------------------------------------

DV - Divider pipe (on port 0)
D - Data fetch pipe (on ports 2 and 3)
F - Macro Fusion with the previous instruction occurred
* - instruction micro-ops not bound to a port
^ - Micro Fusion occurred
# - ESP Tracking sync uop was issued
@ - SSE instruction followed an AVX256/AVX512 instruction, dozens of cycles penalty is expected
X - instruction not supported, was not accounted in Analysis

| Num Of   |                    Ports pressure in cycles                         |      |
|  Uops    |  0  - DV    |  1   |  2  -  D    |  3  -  D    |  4   |  5   |  6   |  7   |
-----------------------------------------------------------------------------------------
|   1*     |             |      |             |             |      |      |      |      | pxor xmm0, xmm0
|   2^     |             | 1.0  | 1.0     1.0 |             |      |      |      |      | pcmpgtb xmm0, xmmword ptr [rip-0x8]
|   1*     |             |      |             |             |      |      |      |      | mov rax, rdi
|   2^     |             |      |             | 1.0     1.0 |      | 1.0  |      |      | por xmm0, xmmword ptr [rip+0x3ef8]
|   2^     |             |      |             |             | 1.0  |      |      | 1.0  | movdqa xmmword ptr [rdi], xmm0
|   1      |             |      |             |             |      |      | 1.0  |      | jmp 0xffffffffffffffe5
Total Num Of Uops: 9
```

### SSSE3 IACA

```
Intel(R) Architecture Code Analyzer Version -  v3.0-28-g1ba2cbb build date: 2017-10-30;16:57:45
Analyzed File -  ssse3
Binary Format - 64Bit
Architecture  -  SKL
Analysis Type - Throughput

Throughput Analysis Report
--------------------------
Block Throughput: 1.49 Cycles       Throughput Bottleneck: FrontEnd
Loop Count:  50
Port Binding In Cycles Per Iteration:
--------------------------------------------------------------------------------------------------
|  Port  |   0   -  DV   |   1   |   2   -  D    |   3   -  D    |   4   |   5   |   6   |   7   |
--------------------------------------------------------------------------------------------------
| Cycles |  0.7     0.0  |  0.7  |  1.5     1.5  |  1.5     1.5  |  1.0  |  1.0  |  0.7  |  1.0  |
--------------------------------------------------------------------------------------------------

DV - Divider pipe (on port 0)
D - Data fetch pipe (on ports 2 and 3)
F - Macro Fusion with the previous instruction occurred
* - instruction micro-ops not bound to a port
^ - Micro Fusion occurred
# - ESP Tracking sync uop was issued
@ - SSE instruction followed an AVX256/AVX512 instruction, dozens of cycles penalty is expected
X - instruction not supported, was not accounted in Analysis

| Num Of   |                    Ports pressure in cycles                         |      |
|  Uops    |  0  - DV    |  1   |  2  -  D    |  3  -  D    |  4   |  5   |  6   |  7   |
-----------------------------------------------------------------------------------------
|   1      |             |      | 0.5     0.5 | 0.5     0.5 |      |      |      |      | movdqa xmm0, xmmword ptr [rip+0x3ef6]
|   2^     |             |      | 0.5     0.5 | 0.5     0.5 |      | 1.0  |      |      | pshufb xmm0, xmmword ptr [rsi]
|   1*     |             |      |             |             |      |      |      |      | mov rax, rdi
|   2^     | 0.3         | 0.7  | 0.5     0.5 | 0.5     0.5 |      |      |      |      | por xmm0, xmmword ptr [rip+0x3ef8]
|   2^     |             |      |             |             | 1.0  |      |      | 1.0  | movdqa xmmword ptr [rdi], xmm0
|   1      | 0.3         |      |             |             |      |      | 0.7  |      | jmp 0xffffffffffffffe4
Total Num Of Uops: 9
```