### PR TITLE
Add additional benchmarks.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -150,12 +150,10 @@ fn insert_8_char_string(b: &mut Bencher) {
         strings.push(format!("{:x}", -i));
     }
 
-
     let mut m = new_map();
     b.iter(|| {
         for key in &strings {
             m.insert(key, key);
         }
     })
-
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -49,6 +49,22 @@ fn grow_by_insertion(b: &mut Bencher) {
 }
 
 #[bench]
+fn grow_by_insertion_kb(b: &mut Bencher) {
+    let mut m = new_map();
+    let kb = 1024;
+    for i in 1..1001 {
+        m.insert(i * kb, i);
+    }
+
+    let mut k = 1001 * kb;
+
+    b.iter(|| {
+        m.insert(k, k);
+        k += kb;
+    });
+}
+
+#[bench]
 fn find_existing(b: &mut Bencher) {
     let mut m = new_map();
 
@@ -59,6 +75,21 @@ fn find_existing(b: &mut Bencher) {
     b.iter(|| {
         for i in 1..1001 {
             m.contains_key(&i);
+        }
+    });
+}
+
+#[bench]
+fn find_existing_high_bits(b: &mut Bencher) {
+    let mut m = new_map();
+
+    for i in 1..1001_u64 {
+        m.insert(i << 32, i);
+    }
+
+    b.iter(|| {
+        for i in 1..1001_u64 {
+            m.contains_key(&(i << 32));
         }
     });
 }
@@ -112,4 +143,21 @@ fn get_remove_insert(b: &mut Bencher) {
         m.insert(k + 1000, k + 1000);
         k += 1;
     })
+}
+
+#[bench]
+fn insert_8_char_string(b: &mut Bencher) {
+    let mut strings: Vec<_> = Vec::new();
+    for i in 1..1001 {
+        strings.push(format!("{:x}", -i));
+    }
+
+
+    let mut m = new_map();
+    b.iter(|| {
+        for key in &strings {
+            m.insert(key, key);
+        }
+    })
+
 }


### PR DESCRIPTION
This covers performance of three cases I wanted to study when looking into https://github.com/Amanieu/hashbrown/issues/48

They are:
`grow_by_insertion_kb` which is similar to grow by insertion, but instead of every entry differing by 1, they differ by 1024. This makes an important performance difference to the hasher.

`find_existing_high_bits` which is similar to find_existing but uses 64 bit keys instead of 32 bit keys, where the lower 32 bits are zeros. This is a pathologically bad case for FxHash.

`insert_8_char_string` tests a case where the key is a string. (As opposed to all the existing tests which operate on u32 values. This is important to cover because strings as keys are very common.