### PR TITLE
Inline non-nightly lowest_set_bit_nonzero

### DIFF
--- a/src/raw/bitmask.rs
+++ b/src/raw/bitmask.rs
@@ -54,6 +54,7 @@ impl BitMask {
     pub unsafe fn lowest_set_bit_nonzero(self) -> usize {
         intrinsics::cttz_nonzero(self.0) as usize / BITMASK_STRIDE
     }
+    #[inline]
     #[cfg(not(feature = "nightly"))]
     pub unsafe fn lowest_set_bit_nonzero(self) -> usize {
         self.trailing_zeros()


### PR DESCRIPTION
I was surprised to see this tiny function show up in my performance
profile on its own. The nightly version of this function was already
marked `#[inline]`, but the non-nightly version should be inlined too.